### PR TITLE
add `}`/`{`  hotkeys to jump between diff hunks

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -468,7 +468,7 @@ pub(crate) fn render_frame(
         layout.columns,
     )));
     lines.push(Line::from(fit_line(
-        "h/l: file  j/k: scroll  ctrl-u/d: page  g/G: top/bottom  /: search  n/N: next/prev match  r: reviewed  q: quit",
+        "h/l: file  j/k: scroll  ctrl-u/d: page  g/G: top/bottom  /: search  n/N: match  }/{: hunk  r: reviewed  q: quit",
         layout.columns,
     )));
     lines.push(Line::from(fit_line(


### PR DESCRIPTION
resolves #1

Navigating large files with few changes was tedious — you had to scroll through all the unchanged lines. `}` jumps to the next hunk start, `{` to the previous, with wrapping at file boundaries.