### PR TITLE
hunk navigation wraps across files

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -37,6 +37,7 @@ fn draw_app<B: Backend>(
         app.reviewed_count(),
         app.is_current_file_reviewed(),
         app.search_status_text(),
+        app.focused_hunk_lines.as_ref(),
         size.width,
         size.height,
     );


### PR DESCRIPTION
resolves https://github.com/flamestro/deff/issues/3

## What changed

- `}`/`{` now jumps between hunks, wrapping across files

## Why

- because it makes the tool easier to use

## User-facing impact

- easier navigation
- subtle highlights for jumped-to hunks

## Validation

- [x] `cargo check --locked`
- [x] Manual testing completed (if applicable)

## Checklist

- [x] PR is focused and scoped to one change
- [x] Docs updated when behavior changes
- [x] Breaking changes called out (if any)
